### PR TITLE
Add a field `status` in the shard_status() command output

### DIFF
--- a/README.md
+++ b/README.md
@@ -205,14 +205,19 @@ Wait until all shards are connected and operational.
 
 #### `shard_status()`
 
-Returns the status of all shards: whether they are online, offline or
+Returns the status of the entire cluster and status of all shards: whether they are online, offline or
 in maintenance.
+Field `status` can be the following values:
+* `ok` - all shards work
+* `degraded` - at least one node in a shard is down, but the shard still works
+* `offline` - one shard is completely down
 
 Example output:
 
 ```yaml
 ---
-- maintenance: []
+- status: ok
+  maintenance: []
   offline: []
   online:
   - uri: localhost:3301

--- a/shard.lua
+++ b/shard.lua
@@ -267,8 +267,10 @@ local function shard_status()
     local result = {
         online = {},
         offline = {},
+        status = 'ok',
         maintenance = maintenance
     }
+    local online_shard = 0
     for j = 1, #shards do
          local srd = shards[j]
          for i = 1, redundancy do
@@ -277,8 +279,13 @@ local function shard_status()
                  table.insert(result.online, s)
              else
                  table.insert(result.offline, s)
+                 result.status = 'degraded'
              end
          end
+         if online_shard == #result.online then
+             result.status = 'offline'
+         end
+         online_shard = #result.online
     end
     return result
 end


### PR DESCRIPTION
This field shows a status of the entire cluster.