### PR TITLE
Fix request method when redundancy > 1

### DIFF
--- a/shard/init.lua
+++ b/shard/init.lua
@@ -1442,7 +1442,14 @@ local function request(self, space, operation, tuple_id, ...)
         return nil, err
     end
 
-    return single_call(self, space, nodes[1], operation, ...)
+    local result = {}
+    for _, server in ipairs(nodes) do
+        table.insert(result, single_call(self, space, server, operation, ...))
+        if configuration.replication == true then
+            break
+        end
+    end
+    return result
 end
 
 local function broadcast_select(task)


### PR DESCRIPTION
At least 'replace' calls did sent data to an one server in a replica set
when tarantool replication is not used.

It is regression of 2.0, see 16434980.